### PR TITLE
Adiciona a descrição da palestra de Go

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -133,7 +133,7 @@
         <article class="speaker">
           <img src="images/toad.jpg" alt="Carlos Maniero">
           <div class="speaker-info">
-            <h4 class="title">Em Breve</h4>
+            <h4 class="title"></h4>
             <p><span class="contact-link"></span></p>
           </div>
         </article>
@@ -200,8 +200,10 @@
 
         <dt class="schedule-hour">09:00 as 09:50</dt>
         <dd class="talk">
-          <span class="talk-title">Palestra a definir</span>
+          <span class="talk-title">Porque desenvolver em Go? (ou não)</span>
           <span class="talk-speaker">Carlos Maniero</span>
+          <p>Longe de ser uma linguagem nova, com quase sete anos desde o primeiro release, Go (GoLang) está sendo cada vez mais utilizada. 
+Promete escalabilidade, simplicidade e tem um dos mascotes mais fofos da história das linguagens de programação. Dado isso, vamos ver um pouco da sintaxe e como Go lida lindamente com concorrência.</p>
         </dd>
 
         <dt class="schedule-hour">09:50 as 10:40</dt>


### PR DESCRIPTION
Esse pull request adiciona a descrição da minha palestra sobre Go na página do evento.

Eu notei que meu nome aparece duas vezes no código, sendo que a segunda aparentemente não é exibida. Sabem dizer o porque?

Se não estiver sendo utilizada, eu posso apagar aqui e enviar outro PR.